### PR TITLE
Correctly configure HPA target

### DIFF
--- a/charts/k8s-service/templates/horizontalpodautoscaler.yaml
+++ b/charts/k8s-service/templates/horizontalpodautoscaler.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ if not .Values.statefulSet }}Deployment{{ else }}StatefulSet{{ end }}
     name: {{ include "k8s-service.fullname" . }}
   minReplicas: {{ .Values.horizontalPodAutoscaler.minReplicas }}
   maxReplicas: {{ .Values.horizontalPodAutoscaler.maxReplicas }}


### PR DESCRIPTION
When the service is deployed as a StatefulSet, it's necessary to configure the HPA target as such.